### PR TITLE
Parsing title from HTML error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,8 @@ migrate_working_dir/
 *.iml
 *.ipr
 *.iws
-.idea/
+.idea/*
+!.idea/.name
 
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+Autogram Sign (AVM Client Dart)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.5
+
+* Parsing title from HTML error body as exception message
+
 ## 0.4.4
 
 * Update API scheme to v0.4.0

--- a/lib/src/response_functions.dart
+++ b/lib/src/response_functions.dart
@@ -57,7 +57,7 @@ BodyType unwrap<BodyType>(Response<BodyType> response) {
     // Parse title from HTML
     if (contentType != null && contentType.startsWith('text/html')) {
       final document = parse(text);
-      final titleElement = document.querySelector('title');
+      final titleElement = document.head?.querySelector('title');
       final titleText = titleElement?.text;
 
       text = titleText ?? "HTTP $statusCode error";

--- a/lib/src/response_functions.dart
+++ b/lib/src/response_functions.dart
@@ -2,6 +2,7 @@ import 'dart:convert' show jsonDecode;
 import 'dart:developer' as developer;
 
 import 'package:chopper/chopper.dart' show Response;
+import 'package:html/parser.dart';
 
 import 'service_exception.dart';
 
@@ -13,15 +14,17 @@ BodyType unwrap<BodyType>(Response<BodyType> response) {
     return response.body as BodyType;
   }
 
-  final error = response.error;
   final statusCode = response.statusCode;
+  final contentType = response.headers['content-type'];
+  var text = response.error;
 
-  if (error is String) {
-    if (error.startsWith("{") && error.endsWith("}")) {
+  if (text is String) {
+    // JSON
+    if (text.startsWith("{") && text.endsWith("}")) {
       dynamic errorJson;
 
       try {
-        errorJson = jsonDecode(error);
+        errorJson = jsonDecode(text);
       } catch (error, stackTrace) {
         developer.log(
           "Error occurred when deserializing error JSON.",
@@ -50,10 +53,19 @@ BodyType unwrap<BodyType>(Response<BodyType> response) {
         }
       }
     }
+
+    // Parse title from HTML
+    if (contentType != null && contentType.startsWith('text/html')) {
+      final document = parse(text);
+      final titleElement = document.querySelector('title');
+      final titleText = titleElement?.text;
+
+      text = titleText ?? "HTTP $statusCode error";
+    }
   }
 
   throw ServiceException(
     statusCode: statusCode,
-    message: error.toString(),
+    message: text.toString(),
   );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,8 @@ environment:
 dependencies:
   chopper: '>=7.4.0 <8.0.0'
   json_annotation: 4.9.0
-  http: any
+  http:
+  html:
   basic_utils: ^5.7.0
   intl: '>=0.18.1 <1.0.0'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: autogram_sign
 description: "Autogram service REST API client"
-version: 0.4.4
+version: 0.4.5
 homepage: ""
 
 environment:

--- a/test/unwap_test.dart
+++ b/test/unwap_test.dart
@@ -56,7 +56,11 @@ void main() {
       final httpResponse = http.Response(responseText, 502, headers: {
         'content-type': 'text/html',
       });
-      final response = chopper.Response<dynamic>(httpResponse, responseText);
+      final response = chopper.Response<dynamic>(
+        httpResponse,
+        null,
+        error: responseText,
+      );
 
       expect(
         () => unwrap(response),

--- a/test/unwap_test.dart
+++ b/test/unwap_test.dart
@@ -44,15 +44,28 @@ void main() {
     });
 
     test('unwrap throws ServiceException for other error status code', () {
-      // TODO Add HTML body with title text and check whether it was parsed
-      final httpResponse = http.Response('', 503);
-      final response = chopper.Response<dynamic>(httpResponse, null);
+      final responseText = """
+<html>
+<head><title>502 Bad Gateway</title></head>
+<body>
+<center><h1>502 Bad Gateway</h1></center>
+<hr><center>nginx</center>
+</body>
+</html>
+""";
+      final httpResponse = http.Response(responseText, 502, headers: {
+        'content-type': 'text/html',
+      });
+      final response = chopper.Response<dynamic>(httpResponse, responseText);
 
       expect(
         () => unwrap(response),
         throwsA(
           predicate(
-            (e) => e is ServiceException && e.statusCode == 503,
+            (e) =>
+                e is ServiceException &&
+                e.statusCode == 502 &&
+                e.message == "502 Bad Gateway",
           ),
         ),
       );

--- a/test/unwap_test.dart
+++ b/test/unwap_test.dart
@@ -44,6 +44,7 @@ void main() {
     });
 
     test('unwrap throws ServiceException for other error status code', () {
+      // TODO Add HTML body with title text and check whether it was parsed
       final httpResponse = http.Response('', 503);
       final response = chopper.Response<dynamic>(httpResponse, null);
 


### PR DESCRIPTION
Ak API vrati error response s content-type: text/html, pouzije sa jeho `title` ako `ServiceException.messge`.

---

predtym:
<img width="720" height="1280" alt="Screenshot_1774694541" src="https://github.com/user-attachments/assets/28c9f870-1daa-459d-ac93-d24f7667f73d" />

potom:
<img width="720" height="1280" alt="Screenshot_1774698369" src="https://github.com/user-attachments/assets/3a2b2359-9bf8-484c-9b5e-0207965b8e07" />